### PR TITLE
Windows testing added

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Check out all text files in UNIX format, with LF as end of line
+# Don't change this file. If you have any ideas about it, please
+# submit a separate issue about it and we'll discuss.
+
+* text=auto eol=lf
+*.java ident
+*.xml ident
+*.png binary

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-12, windows-2022]
         java: [11, 17]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Closes: #7

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Windows 2022 as a target OS in the Maven GitHub action, and sets up the project to use Unix line endings. 

### Detailed summary
- Adds `windows-2022` to the list of supported operating systems in the `mvn.yml` file
- Sets up the project to use Unix line endings in the `.gitattributes` file
- Specifies file types to be treated as text, XML, or binary in the `.gitattributes` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->