### PR TITLE
More tests and entities added

### DIFF
--- a/src/main/java/org/objectionary/entities/FlatObject.java
+++ b/src/main/java/org/objectionary/entities/FlatObject.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.objectionary.entities;
+
+/**
+ * This class represents the flat object entity.
+ * @since 0.1.0
+ */
+public final class FlatObject extends Entity {
+
+    /**
+     * The name of the object.
+     */
+    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+    private final String name;
+
+    /**
+     * The locator of the object.
+     */
+    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+    private final String locator;
+
+    /**
+     * Constructor.
+     * @param name The name of the object.
+     * @param locator The locator of the object.
+     */
+    public FlatObject(final String name, final String locator) {
+        this.name = name;
+        this.locator = locator;
+    }
+
+}

--- a/src/main/java/org/objectionary/entities/Locator.java
+++ b/src/main/java/org/objectionary/entities/Locator.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.objectionary.entities;
+
+/**
+ * This class represents the locator entity.
+ * @since 0.1.0
+ */
+public final class Locator extends Entity {
+
+    /**
+     * The path of the locator.
+     */
+    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+    private final String path;
+
+    /**
+     * Constructor.
+     * @param path The path of the locator.
+     */
+    public Locator(final String path) {
+        this.path = path;
+    }
+}

--- a/src/test/java/org/objectionary/ObjectsBoxTest.java
+++ b/src/test/java/org/objectionary/ObjectsBoxTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.objectionary.entities.Data;
 import org.objectionary.entities.Empty;
 import org.objectionary.entities.Entity;
+import org.objectionary.entities.FlatObject;
+import org.objectionary.entities.Locator;
 
 /**
  * ObjectsBox test.
@@ -65,6 +67,32 @@ final class ObjectsBoxTest {
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("foo(𝜋) ↦ ⟦ Δ ↦ 0x000A ⟧")
+        );
+    }
+
+    @Disabled
+    @Test
+    void boxWithLocatorToStringTest() {
+        final ObjectsBox box = new ObjectsBox();
+        final Map<String, Entity> bindings = new HashMap<>();
+        bindings.put("x", new Locator("𝜋.𝜋.y"));
+        box.put("bar", bindings);
+        MatcherAssert.assertThat(
+            box.toString(),
+            Matchers.equalTo("bar(𝜋) ↦ ⟦ x ↦ 𝜋.𝜋.y ⟧")
+        );
+    }
+
+    @Disabled
+    @Test
+    void boxWithFlatObjectToStringTest() {
+        final ObjectsBox box = new ObjectsBox();
+        final Map<String, Entity> bindings = new HashMap<>();
+        bindings.put("y", new FlatObject("bar", "𝜋.𝜋"));
+        box.put("foo", bindings);
+        MatcherAssert.assertThat(
+            box.toString(),
+            Matchers.equalTo("foo(𝜋) ↦ ⟦ y ↦ bar(𝜋.𝜋) ⟧")
         );
     }
 }


### PR DESCRIPTION
Closes: #30 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds two new entity classes, `Locator` and `FlatObject`, to the `org.objectionary.entities` package. It also adds tests for the `ObjectsBox` class that use these new entities.

### Detailed summary
- Adds `Locator` and `FlatObject` entity classes to `org.objectionary.entities` package.
- Adds tests for `ObjectsBox` class that use these new entities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->