### PR TITLE
Complex order tests created

### DIFF
--- a/src/test/java/org/objectionary/ObjectsBoxTest.java
+++ b/src/test/java/org/objectionary/ObjectsBoxTest.java
@@ -128,21 +128,15 @@ final class ObjectsBoxTest {
     @Test
     void zeroObjectOrderTest() {
         final ObjectsBox box = new ObjectsBox();
-        {
-            final Map<String, Entity> bindings = new HashMap<>();
-            bindings.put("x", new Empty());
-            box.put("a", bindings);
-        }
-        {
-            final Map<String, Entity> bindings = new HashMap<>();
-            bindings.put("y", new Empty());
-            box.put("b", bindings);
-        }
-        {
-            final Map<String, Entity> bindings = new HashMap<>();
-            bindings.put("z", new Empty());
-            box.put("ν0", bindings);
-        }
+        Map<String, Entity> bindings = new HashMap<>();
+        bindings.put("x", new Empty());
+        box.put("a", bindings);
+        bindings = new HashMap<>();
+        bindings.put("y", new Empty());
+        box.put("b", bindings);
+        bindings = new HashMap<>();
+        bindings.put("z", new Empty());
+        box.put("ν0", bindings);
         final String result = box.toString();
         assert result != null;
         MatcherAssert.assertThat(
@@ -160,7 +154,7 @@ final class ObjectsBoxTest {
         bindings.put("x", new Empty());
         bindings.put("y", new FlatObject("bar", "𝜋"));
         bindings.put("a", new Lambda("Atom"));
-        box.put("foo", bindings);
+        box.put("func", bindings);
         final String result = box.toString();
         assert result != null;
         MatcherAssert.assertThat(
@@ -178,12 +172,12 @@ final class ObjectsBoxTest {
         bindings.put("a1", new Empty());
         bindings.put("a2", new FlatObject("bar", "𝜋"));
         bindings.put("a3", new Lambda("Atom"));
-        box.put("foo", bindings);
+        box.put("func", bindings);
         final String result = box.toString();
         assert result != null;
         MatcherAssert.assertThat(
-                result.split(" ")[3],
-                Matchers.equalTo("λ")
+            result.split(" ")[3],
+            Matchers.equalTo("λ")
         );
     }
 
@@ -194,14 +188,14 @@ final class ObjectsBoxTest {
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("𝜑", new Data(Integer.parseInt("000A", 16)));
         bindings.put("a", new Empty());
-        bindings.put("b", new FlatObject("bar", "𝜋"));
+        bindings.put("b", new FlatObject("d", "𝜋"));
         bindings.put("c", new Lambda("Atom"));
-        box.put("foo", bindings);
+        box.put("f", bindings);
         final String result = box.toString();
         assert result != null;
         MatcherAssert.assertThat(
-                result.split(" ")[3],
-                Matchers.equalTo("𝜑")
+            result.split(" ")[3],
+            Matchers.equalTo("𝜑")
         );
     }
 }

--- a/src/test/java/org/objectionary/ObjectsBoxTest.java
+++ b/src/test/java/org/objectionary/ObjectsBoxTest.java
@@ -90,11 +90,11 @@ final class ObjectsBoxTest {
     void boxWithFlatObjectToStringTest() {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
-        bindings.put("y", new FlatObject("bar", "𝜋.𝜋"));
+        bindings.put("y", new FlatObject("bar", "ξ"));
         box.put("foo", bindings);
         MatcherAssert.assertThat(
             box.toString(),
-            Matchers.equalTo("foo(𝜋) ↦ ⟦ y ↦ bar(𝜋.𝜋) ⟧")
+            Matchers.equalTo("foo(𝜋) ↦ ⟦ y ↦ bar(ξ) ⟧")
         );
     }
 
@@ -123,6 +123,87 @@ final class ObjectsBoxTest {
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("foo(𝜋) ↦ ⟦ y ↦ v( x ↦ 𝜋.𝜋.z ) ⟧")
+        );
+    }
+
+    @Disabled
+    @Test
+    void zeroObjectOrderTest() {
+        final ObjectsBox box = new ObjectsBox();
+        {
+            final Map<String, Entity> bindings = new HashMap<>();
+            bindings.put("x", new Empty());
+            box.put("a", bindings);
+        }
+        {
+            final Map<String, Entity> bindings = new HashMap<>();
+            bindings.put("y", new Empty());
+            box.put("b", bindings);
+        }
+        {
+            final Map<String, Entity> bindings = new HashMap<>();
+            bindings.put("z", new Empty());
+            box.put("ν0", bindings);
+        }
+        final String result = box.toString();
+        assert result != null;
+        MatcherAssert.assertThat(
+            result.split("\n")[0],
+            Matchers.equalTo("ν0(𝜋) ↦ ⟦ z ↦ ø ⟧")
+        );
+    }
+
+    @Disabled
+    @Test
+    void deltaOrderTest() {
+        final ObjectsBox box = new ObjectsBox();
+        final Map<String, Entity> bindings = new HashMap<>();
+        bindings.put("Δ", new Data(Integer.parseInt("000A", 16)));
+        bindings.put("x", new Empty());
+        bindings.put("y", new FlatObject("bar", "𝜋"));
+        bindings.put("a", new Lambda("Atom"));
+        box.put("foo", bindings);
+        final String result = box.toString();
+        assert result != null;
+        MatcherAssert.assertThat(
+            result.split(" ")[3],
+            Matchers.equalTo("Δ")
+        );
+    }
+
+    @Disabled
+    @Test
+    void lambdaOrderTest() {
+        final ObjectsBox box = new ObjectsBox();
+        final Map<String, Entity> bindings = new HashMap<>();
+        bindings.put("λ", new Data(Integer.parseInt("000A", 16)));
+        bindings.put("a1", new Empty());
+        bindings.put("a2", new FlatObject("bar", "𝜋"));
+        bindings.put("a3", new Lambda("Atom"));
+        box.put("foo", bindings);
+        final String result = box.toString();
+        assert result != null;
+        MatcherAssert.assertThat(
+                result.split(" ")[3],
+                Matchers.equalTo("λ")
+        );
+    }
+
+    @Disabled
+    @Test
+    void phiOrderTest() {
+        final ObjectsBox box = new ObjectsBox();
+        final Map<String, Entity> bindings = new HashMap<>();
+        bindings.put("𝜑", new Data(Integer.parseInt("000A", 16)));
+        bindings.put("a", new Empty());
+        bindings.put("b", new FlatObject("bar", "𝜋"));
+        bindings.put("c", new Lambda("Atom"));
+        box.put("foo", bindings);
+        final String result = box.toString();
+        assert result != null;
+        MatcherAssert.assertThat(
+                result.split(" ")[3],
+                Matchers.equalTo("𝜑")
         );
     }
 }

--- a/src/test/java/org/objectionary/ObjectsBoxTest.java
+++ b/src/test/java/org/objectionary/ObjectsBoxTest.java
@@ -41,8 +41,6 @@ import org.objectionary.entities.NestedObject;
  * ObjectsBox test.
  *
  * @since 0.1.0
- * @todo #25:30min In future we have to add more complex tests for ObjectsBox.
- *  At least we have to add tests to check v0 order and Δ, λ, 𝜑 orders.
  */
 final class ObjectsBoxTest {
 


### PR DESCRIPTION
Closes: #29 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds tests for different orders and complex objects in `ObjectsBox`. 

### Detailed summary
- Added tests for v0 order, Δ, λ, and 𝜑 orders in `ObjectsBox`
- Updated `boxWithFlatObjectToStringTest()` to use `ξ` instead of `𝜋.𝜋`
- Minor refactoring

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->