### PR TITLE
Objects to string implemented

### DIFF
--- a/src/main/java/org/objectionary/ObjectsBox.java
+++ b/src/main/java/org/objectionary/ObjectsBox.java
@@ -23,8 +23,11 @@
  */
 package org.objectionary;
 
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.objectionary.entities.Entity;
 
 /**
@@ -78,7 +81,6 @@ public final class ObjectsBox {
      *  It should return a string representation of the objects box,
      *  which will be used in phi emulator.
      */
-
     @Override
     public String toString() {
         if (!this.box.containsKey("ν0")) {
@@ -91,7 +93,7 @@ public final class ObjectsBox {
                 continue;
             }
             results.add(
-                    ObjectsBox.objectToString(entry.getKey(), entry.getValue())
+                ObjectsBox.objectToString(entry.getKey(), entry.getValue())
             );
         }
         return String.join("\n", results);

--- a/src/main/java/org/objectionary/ObjectsBox.java
+++ b/src/main/java/org/objectionary/ObjectsBox.java
@@ -77,9 +77,6 @@ public final class ObjectsBox {
     /**
      * Converts the box of objects to a string.
      * @checkstyle NoJavadocForOverriddenMethodsCheck (10 lines)
-     * @todo #25:30min We have to implement the toString() method.
-     *  It should return a string representation of the objects box,
-     *  which will be used in phi emulator.
      */
     @Override
     public String toString() {

--- a/src/main/java/org/objectionary/ObjectsBox.java
+++ b/src/main/java/org/objectionary/ObjectsBox.java
@@ -23,8 +23,8 @@
  */
 package org.objectionary;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+
 import org.objectionary.entities.Entity;
 
 /**
@@ -78,9 +78,56 @@ public final class ObjectsBox {
      *  It should return a string representation of the objects box,
      *  which will be used in phi emulator.
      */
+
     @Override
     public String toString() {
-        return null;
+        if (!this.box.containsKey("ν0")) {
+            throw new IllegalArgumentException("The box does not contain the object ν0.");
+        }
+        final List<String> results = new ArrayList<>(this.box.size());
+        results.add(ObjectsBox.objectToString("ν0", this.box.get("ν0")));
+        for (final Map.Entry<String, Map<String, Entity>> entry : this.box.entrySet()) {
+            if (entry.getKey().equals("ν0")) {
+                continue;
+            }
+            results.add(
+                    ObjectsBox.objectToString(entry.getKey(), entry.getValue())
+            );
+        }
+        return String.join("\n", results);
+    }
+
+    /**
+     * Converts an object to a string.
+     * @param name The name of the object.
+     * @param bindings The bindings of the object.
+     * @return The string representation of the object.
+     */
+    private static String objectToString(
+        final String name, final Map<String, Entity> bindings
+    ) {
+        final List<String> dataizations = Arrays.asList("Δ", "𝜋", "λ");
+        final List<String> result = new ArrayList<>(bindings.size());
+        for (final String binding : dataizations) {
+            if (bindings.containsKey(binding)) {
+                result.add(
+                    String.format("%s ↦ %s", binding, bindings.get(binding))
+                );
+            }
+        }
+        for (final Map.Entry<String, Entity> binding : bindings.entrySet()) {
+            if (dataizations.contains(binding.getKey())) {
+                continue;
+            }
+            result.add(
+                String.format("%s ↦ %s", binding.getKey(), binding.getValue())
+            );
+        }
+        return String.format(
+            "%s(𝜋) ↦ ⟦ %s ⟧",
+            name,
+            String.join(", ", result)
+        );
     }
 
 }

--- a/src/main/java/org/objectionary/ObjectsBox.java
+++ b/src/main/java/org/objectionary/ObjectsBox.java
@@ -105,7 +105,7 @@ public final class ObjectsBox {
     private static String objectToString(
         final String name, final Map<String, Entity> bindings
     ) {
-        final List<String> dataizations = Arrays.asList("Δ", "𝜋", "λ");
+        final List<String> dataizations = Arrays.asList("Δ", "𝜑", "λ");
         final List<String> result = new ArrayList<>(bindings.size());
         for (final String binding : dataizations) {
             if (bindings.containsKey(binding)) {

--- a/src/main/java/org/objectionary/ObjectsBox.java
+++ b/src/main/java/org/objectionary/ObjectsBox.java
@@ -84,13 +84,13 @@ public final class ObjectsBox {
             throw new IllegalArgumentException("The box does not contain the object ν0.");
         }
         final List<String> results = new ArrayList<>(this.box.size());
-        results.add(ObjectsBox.objectToString("ν0", this.box.get("ν0")));
+        results.add(ObjectsBox.serialize("ν0", this.box.get("ν0")));
         for (final Map.Entry<String, Map<String, Entity>> entry : this.box.entrySet()) {
             if (entry.getKey().equals("ν0")) {
                 continue;
             }
             results.add(
-                ObjectsBox.objectToString(entry.getKey(), entry.getValue())
+                ObjectsBox.serialize(entry.getKey(), entry.getValue())
             );
         }
         return String.join("\n", results);
@@ -102,7 +102,7 @@ public final class ObjectsBox {
      * @param bindings The bindings of the object.
      * @return The string representation of the object.
      */
-    private static String objectToString(
+    private static String serialize(
         final String name, final Map<String, Entity> bindings
     ) {
         final List<String> dataizations = Arrays.asList("Δ", "𝜑", "λ");

--- a/src/main/java/org/objectionary/entities/Data.java
+++ b/src/main/java/org/objectionary/entities/Data.java
@@ -32,7 +32,6 @@ public final class Data extends Entity {
     /**
      * The data value.
      */
-    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     private final int value;
 
     /**
@@ -41,5 +40,10 @@ public final class Data extends Entity {
      */
     public Data(final int value) {
         this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("0x%04X", this.value);
     }
 }

--- a/src/main/java/org/objectionary/entities/Empty.java
+++ b/src/main/java/org/objectionary/entities/Empty.java
@@ -28,4 +28,9 @@ package org.objectionary.entities;
  * @since 0.1.0
  */
 public final class Empty extends Entity {
+
+    @Override
+    public String toString() {
+        return "ø";
+    }
 }

--- a/src/main/java/org/objectionary/entities/FlatObject.java
+++ b/src/main/java/org/objectionary/entities/FlatObject.java
@@ -51,4 +51,9 @@ public final class FlatObject extends Entity {
         this.locator = locator;
     }
 
+    @Override
+    public String toString() {
+        return this.locator.isEmpty() ? this.name : String.format("%s(%s)", this.name, this.locator);
+    }
+
 }

--- a/src/main/java/org/objectionary/entities/FlatObject.java
+++ b/src/main/java/org/objectionary/entities/FlatObject.java
@@ -32,13 +32,11 @@ public final class FlatObject extends Entity {
     /**
      * The name of the object.
      */
-    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     private final String name;
 
     /**
      * The locator of the object.
      */
-    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     private final String locator;
 
     /**

--- a/src/main/java/org/objectionary/entities/FlatObject.java
+++ b/src/main/java/org/objectionary/entities/FlatObject.java
@@ -53,7 +53,13 @@ public final class FlatObject extends Entity {
 
     @Override
     public String toString() {
-        return this.locator.isEmpty() ? this.name : String.format("%s(%s)", this.name, this.locator);
+        final String result;
+        if (this.locator.isEmpty()) {
+            result = this.name;
+        } else {
+            result = String.format("%s(%s)", this.name, this.locator);
+        }
+        return result;
     }
 
 }

--- a/src/main/java/org/objectionary/entities/Lambda.java
+++ b/src/main/java/org/objectionary/entities/Lambda.java
@@ -42,4 +42,9 @@ public final class Lambda extends Entity {
     public Lambda(final String function) {
         this.function = function;
     }
+
+    @Override
+    public String toString() {
+        return this.function;
+    }
 }

--- a/src/main/java/org/objectionary/entities/Lambda.java
+++ b/src/main/java/org/objectionary/entities/Lambda.java
@@ -32,7 +32,6 @@ public final class Lambda extends Entity {
     /**
      * The function of the lambda.
      */
-    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     private final String function;
 
     /**

--- a/src/main/java/org/objectionary/entities/Locator.java
+++ b/src/main/java/org/objectionary/entities/Locator.java
@@ -42,4 +42,9 @@ public final class Locator extends Entity {
     public Locator(final String path) {
         this.path = path;
     }
+
+    @Override
+    public String toString() {
+        return this.path;
+    }
 }

--- a/src/main/java/org/objectionary/entities/Locator.java
+++ b/src/main/java/org/objectionary/entities/Locator.java
@@ -32,7 +32,6 @@ public final class Locator extends Entity {
     /**
      * The path of the locator.
      */
-    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     private final String path;
 
     /**

--- a/src/main/java/org/objectionary/entities/NestedObject.java
+++ b/src/main/java/org/objectionary/entities/NestedObject.java
@@ -52,4 +52,19 @@ public final class NestedObject extends Entity {
         this.name = name;
         this.application = application;
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder buffer = new StringBuilder();
+        final int size = this.application.size();
+        int count = 0;
+        for (final Map.Entry<String, Entity> entry : this.application.entrySet()) {
+            buffer.append(entry.getKey()).append(" ↦ ").append(entry.getValue());
+            count += 1;
+            if (count < size) {
+                buffer.append(", ");
+            }
+        }
+        return String.format("%s(%s)", this.name, buffer);
+    }
 }

--- a/src/main/java/org/objectionary/entities/NestedObject.java
+++ b/src/main/java/org/objectionary/entities/NestedObject.java
@@ -65,6 +65,6 @@ public final class NestedObject extends Entity {
                 buffer.append(", ");
             }
         }
-        return String.format("%s(%s)", this.name, buffer);
+        return String.format("%s( %s )", this.name, buffer);
     }
 }

--- a/src/main/java/org/objectionary/entities/NestedObject.java
+++ b/src/main/java/org/objectionary/entities/NestedObject.java
@@ -34,13 +34,11 @@ public final class NestedObject extends Entity {
     /**
      * The name of the object with application.
      */
-    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     private final String name;
 
     /**
      * The application of the object with application.
      */
-    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     private final Map<String, Entity> application;
 
     /**

--- a/src/test/java/org/objectionary/ObjectsBoxTest.java
+++ b/src/test/java/org/objectionary/ObjectsBoxTest.java
@@ -156,7 +156,6 @@ final class ObjectsBoxTest {
         bindings.put("a", new Lambda("Atom"));
         box.put("func", bindings);
         final String result = box.toString();
-        assert result != null;
         MatcherAssert.assertThat(
             result.split(" ")[3],
             Matchers.equalTo("Δ")
@@ -174,7 +173,6 @@ final class ObjectsBoxTest {
         bindings.put("a3", new Lambda("Atom"));
         box.put("func", bindings);
         final String result = box.toString();
-        assert result != null;
         MatcherAssert.assertThat(
             result.split(" ")[3],
             Matchers.equalTo("λ")
@@ -192,7 +190,6 @@ final class ObjectsBoxTest {
         bindings.put("c", new Lambda("Atom"));
         box.put("f", bindings);
         final String result = box.toString();
-        assert result != null;
         MatcherAssert.assertThat(
             result.split(" ")[3],
             Matchers.equalTo("𝜑")

--- a/src/test/java/org/objectionary/ObjectsBoxTest.java
+++ b/src/test/java/org/objectionary/ObjectsBoxTest.java
@@ -43,12 +43,17 @@ import org.objectionary.entities.NestedObject;
  */
 final class ObjectsBoxTest {
 
+    /**
+     * Literal for v0.
+     */
+    private static final String INIT_OBJECT = "ν0";
+
     @Test
     void boxWithEmptyToStringTest() {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("x", new Empty());
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("ν0(𝜋) ↦ ⟦ x ↦ ø ⟧")
@@ -60,7 +65,7 @@ final class ObjectsBoxTest {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("Δ", new Data(Integer.parseInt("000A", 16)));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("ν0(𝜋) ↦ ⟦ Δ ↦ 0x000A ⟧")
@@ -72,7 +77,7 @@ final class ObjectsBoxTest {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("x", new Locator("𝜋.𝜋.y"));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("ν0(𝜋) ↦ ⟦ x ↦ 𝜋.𝜋.y ⟧")
@@ -84,7 +89,7 @@ final class ObjectsBoxTest {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("y", new FlatObject("bar", "ξ"));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("ν0(𝜋) ↦ ⟦ y ↦ bar(ξ) ⟧")
@@ -96,7 +101,7 @@ final class ObjectsBoxTest {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("λ", new Lambda("Plus"));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("ν0(𝜋) ↦ ⟦ λ ↦ Plus ⟧")
@@ -110,7 +115,7 @@ final class ObjectsBoxTest {
         application.put("x", new Locator("𝜋.𝜋.z"));
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("y", new NestedObject("v", application));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         MatcherAssert.assertThat(
             box.toString(),
             Matchers.equalTo("ν0(𝜋) ↦ ⟦ y ↦ v( x ↦ 𝜋.𝜋.z ) ⟧")
@@ -128,7 +133,7 @@ final class ObjectsBoxTest {
         box.put("b", bindings);
         bindings = new HashMap<>();
         bindings.put("z", new Empty());
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         final String result = box.toString();
         MatcherAssert.assertThat(
             result.split("\n")[0],
@@ -144,7 +149,7 @@ final class ObjectsBoxTest {
         bindings.put("x", new Empty());
         bindings.put("y", new FlatObject("bar", "𝜋"));
         bindings.put("a", new Lambda("Atom"));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         final String result = box.toString();
         MatcherAssert.assertThat(
             result.split(" ")[3],
@@ -160,7 +165,7 @@ final class ObjectsBoxTest {
         bindings.put("a1", new Empty());
         bindings.put("a2", new FlatObject("bar", "𝜋"));
         bindings.put("a3", new Lambda("Atom"));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         final String result = box.toString();
         MatcherAssert.assertThat(
             result.split(" ")[3],
@@ -176,7 +181,7 @@ final class ObjectsBoxTest {
         bindings.put("a", new Empty());
         bindings.put("b", new FlatObject("d", "𝜋"));
         bindings.put("c", new Lambda("Atom"));
-        box.put("ν0", bindings);
+        box.put(ObjectsBoxTest.INIT_OBJECT, bindings);
         final String result = box.toString();
         MatcherAssert.assertThat(
             result.split(" ")[3],

--- a/src/test/java/org/objectionary/ObjectsBoxTest.java
+++ b/src/test/java/org/objectionary/ObjectsBoxTest.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectionary.entities.Data;
 import org.objectionary.entities.Empty;
@@ -44,72 +43,66 @@ import org.objectionary.entities.NestedObject;
  */
 final class ObjectsBoxTest {
 
-    @Disabled
     @Test
     void boxWithEmptyToStringTest() {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("x", new Empty());
-        box.put("foo", bindings);
+        box.put("ν0", bindings);
         MatcherAssert.assertThat(
             box.toString(),
-            Matchers.equalTo("foo(𝜋) ↦ ⟦ x ↦ ø ⟧")
+            Matchers.equalTo("ν0(𝜋) ↦ ⟦ x ↦ ø ⟧")
         );
     }
 
-    @Disabled
     @Test
     void boxWithDataToStringTest() {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("Δ", new Data(Integer.parseInt("000A", 16)));
-        box.put("foo", bindings);
+        box.put("ν0", bindings);
         MatcherAssert.assertThat(
             box.toString(),
-            Matchers.equalTo("foo(𝜋) ↦ ⟦ Δ ↦ 0x000A ⟧")
+            Matchers.equalTo("ν0(𝜋) ↦ ⟦ Δ ↦ 0x000A ⟧")
         );
     }
 
-    @Disabled
     @Test
     void boxWithLocatorToStringTest() {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("x", new Locator("𝜋.𝜋.y"));
-        box.put("bar", bindings);
+        box.put("ν0", bindings);
         MatcherAssert.assertThat(
             box.toString(),
-            Matchers.equalTo("bar(𝜋) ↦ ⟦ x ↦ 𝜋.𝜋.y ⟧")
+            Matchers.equalTo("ν0(𝜋) ↦ ⟦ x ↦ 𝜋.𝜋.y ⟧")
         );
     }
 
-    @Disabled
     @Test
     void boxWithFlatObjectToStringTest() {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("y", new FlatObject("bar", "ξ"));
-        box.put("foo", bindings);
+        box.put("ν0", bindings);
         MatcherAssert.assertThat(
             box.toString(),
-            Matchers.equalTo("foo(𝜋) ↦ ⟦ y ↦ bar(ξ) ⟧")
+            Matchers.equalTo("ν0(𝜋) ↦ ⟦ y ↦ bar(ξ) ⟧")
         );
     }
 
-    @Disabled
     @Test
     void boxWithLambdaToStringTest() {
         final ObjectsBox box = new ObjectsBox();
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("λ", new Lambda("Plus"));
-        box.put("v", bindings);
+        box.put("ν0", bindings);
         MatcherAssert.assertThat(
             box.toString(),
-            Matchers.equalTo("v(𝜋) ↦ ⟦ λ ↦ Plus ⟧")
+            Matchers.equalTo("ν0(𝜋) ↦ ⟦ λ ↦ Plus ⟧")
         );
     }
 
-    @Disabled
     @Test
     void boxWithNestedObjectToStringTest() {
         final ObjectsBox box = new ObjectsBox();
@@ -117,14 +110,13 @@ final class ObjectsBoxTest {
         application.put("x", new Locator("𝜋.𝜋.z"));
         final Map<String, Entity> bindings = new HashMap<>();
         bindings.put("y", new NestedObject("v", application));
-        box.put("foo", bindings);
+        box.put("ν0", bindings);
         MatcherAssert.assertThat(
             box.toString(),
-            Matchers.equalTo("foo(𝜋) ↦ ⟦ y ↦ v( x ↦ 𝜋.𝜋.z ) ⟧")
+            Matchers.equalTo("ν0(𝜋) ↦ ⟦ y ↦ v( x ↦ 𝜋.𝜋.z ) ⟧")
         );
     }
 
-    @Disabled
     @Test
     void zeroObjectOrderTest() {
         final ObjectsBox box = new ObjectsBox();
@@ -138,14 +130,12 @@ final class ObjectsBoxTest {
         bindings.put("z", new Empty());
         box.put("ν0", bindings);
         final String result = box.toString();
-        assert result != null;
         MatcherAssert.assertThat(
             result.split("\n")[0],
             Matchers.equalTo("ν0(𝜋) ↦ ⟦ z ↦ ø ⟧")
         );
     }
 
-    @Disabled
     @Test
     void deltaOrderTest() {
         final ObjectsBox box = new ObjectsBox();
@@ -154,7 +144,7 @@ final class ObjectsBoxTest {
         bindings.put("x", new Empty());
         bindings.put("y", new FlatObject("bar", "𝜋"));
         bindings.put("a", new Lambda("Atom"));
-        box.put("func", bindings);
+        box.put("ν0", bindings);
         final String result = box.toString();
         MatcherAssert.assertThat(
             result.split(" ")[3],
@@ -162,7 +152,6 @@ final class ObjectsBoxTest {
         );
     }
 
-    @Disabled
     @Test
     void lambdaOrderTest() {
         final ObjectsBox box = new ObjectsBox();
@@ -171,7 +160,7 @@ final class ObjectsBoxTest {
         bindings.put("a1", new Empty());
         bindings.put("a2", new FlatObject("bar", "𝜋"));
         bindings.put("a3", new Lambda("Atom"));
-        box.put("func", bindings);
+        box.put("ν0", bindings);
         final String result = box.toString();
         MatcherAssert.assertThat(
             result.split(" ")[3],
@@ -179,7 +168,6 @@ final class ObjectsBoxTest {
         );
     }
 
-    @Disabled
     @Test
     void phiOrderTest() {
         final ObjectsBox box = new ObjectsBox();
@@ -188,7 +176,7 @@ final class ObjectsBoxTest {
         bindings.put("a", new Empty());
         bindings.put("b", new FlatObject("d", "𝜋"));
         bindings.put("c", new Lambda("Atom"));
-        box.put("f", bindings);
+        box.put("ν0", bindings);
         final String result = box.toString();
         MatcherAssert.assertThat(
             result.split(" ")[3],


### PR DESCRIPTION
Closes: #28

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `toString()` methods to several classes in the `entities` package and `ObjectsBox` class, improving the readability of their string representations.

### Detailed summary
- Added `toString()` methods to `Empty`, `Locator`, `Data`, `Lambda`, `FlatObject`, `NestedObject`, and `ObjectsBox` classes.
- Improved string representations of objects in `ObjectsBox` by sorting bindings by their type (`Δ`, `λ`, and other bindings) and using `𝜋` to represent locators.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->