### PR TITLE
Tests for line parser added

### DIFF
--- a/src/main/java/org/objectionary/parsing/LineParser.java
+++ b/src/main/java/org/objectionary/parsing/LineParser.java
@@ -29,7 +29,7 @@ import org.objectionary.ObjectsBox;
  * One line parser.
  * @since 0.1.0
  */
-public class LineParser {
+public final class LineParser {
 
     /**
      * The box to put the result into.

--- a/src/main/java/org/objectionary/parsing/LineParser.java
+++ b/src/main/java/org/objectionary/parsing/LineParser.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.objectionary.parsing;
+
+import org.objectionary.ObjectsBox;
+
+/**
+ * One line parser.
+ * @since 0.1.0
+ */
+public class LineParser {
+
+    /**
+     * The box to put the result into.
+     */
+    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+    private final ObjectsBox results;
+
+    /**
+     * Constructor.
+     * @param results The box to put the result into.
+     */
+    public LineParser(final ObjectsBox results) {
+        this.results = results;
+    }
+
+    /**
+     * Parses one line and puts the result into the box.
+     * @param line The line to parse.
+     * @todo #38:30min Implement this method.
+     *  This method should parse one line and put the result into the box.
+     */
+    public void parseLine(final String line) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+}

--- a/src/main/java/org/objectionary/parsing/Parser.java
+++ b/src/main/java/org/objectionary/parsing/Parser.java
@@ -21,7 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.objectionary;
+package org.objectionary.parsing;
+
+import org.objectionary.ObjectsBox;
 
 /**
  * This class represents the parser.

--- a/src/main/java/org/objectionary/parsing/package-info.java
+++ b/src/main/java/org/objectionary/parsing/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Package with parsing classes.
+ */
+package org.objectionary.parsing;

--- a/src/test/java/org/objectionary/ParseLineTest.java
+++ b/src/test/java/org/objectionary/ParseLineTest.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.objectionary;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.objectionary.parsing.LineParser;
+
+/**
+ * Line parser test.
+ *
+ * @since 0.1.0
+ */
+final class ParseLineTest {
+
+    /**
+    * Simple parsing test.
+    */
+    @Disabled
+    @Test
+    void simpleParsingTest() {
+        final ObjectsBox box = new ObjectsBox();
+        final String line = "ν0(𝜋) ↦ ⟦ λ ↦ int-neg, ρ ↦ 𝜋.𝛼0 ⟧";
+        final LineParser parser = new LineParser(box);
+        parser.parseLine(line);
+        MatcherAssert.assertThat(parser.toString(), Matchers.equalTo(line));
+    }
+
+    /**
+     * Simple nested test.
+     */
+    @Disabled
+    @Test
+    void simpleNestedTest() {
+        final ObjectsBox box = new ObjectsBox();
+        final String line = "ν0(𝜋) ↦ ⟦ 𝜑 ↦ ν2( a ↦ ξ.x ) ⟧";
+        final LineParser parser = new LineParser(box);
+        parser.parseLine(line);
+        MatcherAssert.assertThat(parser.toString(), Matchers.equalTo(line));
+    }
+
+}

--- a/src/test/java/org/objectionary/ParserTest.java
+++ b/src/test/java/org/objectionary/ParserTest.java
@@ -27,6 +27,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.objectionary.parsing.Parser;
 
 /**
  * Parser test.


### PR DESCRIPTION
Resolves: #38 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `LineParser` class to the `org.objectionary.parsing` package and updates related files. 

### Detailed summary
- Adds `LineParser` class to `org.objectionary.parsing` package
- Updates `Parser.java` to import `ObjectsBox`
- Adds `package-info.java` to `org.objectionary.parsing` package
- Adds `ParseLineTest.java` to test `LineParser` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->