### PR TITLE
One entity reading implemented

### DIFF
--- a/src/main/java/org/objectionary/Tokenizer.java
+++ b/src/main/java/org/objectionary/Tokenizer.java
@@ -58,15 +58,8 @@ public final class Tokenizer {
      * Checks if there are more tokens.
      * @return True if there are more tokens.
      */
-    boolean hasNext() {
+    public boolean hasNext() {
         return this.position < this.tokens.length;
-    }
-
-    /**
-     * Increments the position.
-     */
-    public void next() {
-        this.position += 1;
     }
 
     /**
@@ -95,4 +88,11 @@ public final class Tokenizer {
         return result;
     }
 
+    /**
+     * Increments the position.
+     */
+    public void next() {
+        this.position += 1;
+    }
 }
+

--- a/src/main/java/org/objectionary/Tokenizer.java
+++ b/src/main/java/org/objectionary/Tokenizer.java
@@ -65,7 +65,7 @@ public final class Tokenizer {
     /**
      * Increments the position.
      */
-    void next() {
+    public void next() {
         this.position += 1;
     }
 

--- a/src/main/java/org/objectionary/Tokenizer.java
+++ b/src/main/java/org/objectionary/Tokenizer.java
@@ -73,7 +73,7 @@ public final class Tokenizer {
      * Returns the current token.
      * @return The current token.
      */
-    Token getToken() {
+    public Token getToken() {
         final String token = this.tokens[this.position];
         final Token result;
         switch (token) {

--- a/src/main/java/org/objectionary/parsing/Entities.java
+++ b/src/main/java/org/objectionary/parsing/Entities.java
@@ -55,8 +55,6 @@ public final class Entities {
     /**
      * Reads one entity.
      * @return The parsed entity.
-     * @todo #49:30min Implement this method.
-     *  This method should read one entity recursively.
      */
     public Entity one() {
         final Token token = tokenizer.getToken();
@@ -75,7 +73,7 @@ public final class Entities {
         } else if (type.isLambda()) {
             result = new Lambda(value);
         } else if (type.isObject()) {
-            result = createObject(tokenizer, value);
+            result = createObject(value);
         } else {
             System.out.println(value);
             throw new IllegalArgumentException("Unknown token");
@@ -91,5 +89,31 @@ public final class Entities {
      */
     public Map<String, Entity> nested() {
         return new HashMap<>();
+    }
+
+    /**
+     * Creates an object.
+     * @param value The value to parse.
+     * @return The parsed entity.
+     * @todo #51:30min Implement this method.
+     *  This method should parse the value and create an object.
+     */
+    private Entity createObject(final String value) {
+        final Entity result;
+        if (value.contains(")")) {
+            result = new FlatObject(
+                value.substring(0, value.indexOf('(')),
+                value.substring(value.indexOf('(') + 1, value.indexOf(')'))
+            );
+        } else if (value.contains("(")) {
+            tokenizer.next();
+            final Map<String, Entity> application = nested();
+            result = new NestedObject(
+                value.substring(0, value.indexOf('(')), application
+            );
+        } else {
+            result = new FlatObject(value, "");
+        }
+        return result;
     }
 }

--- a/src/main/java/org/objectionary/parsing/Entities.java
+++ b/src/main/java/org/objectionary/parsing/Entities.java
@@ -95,8 +95,6 @@ public final class Entities {
      * Creates an object.
      * @param value The value to parse.
      * @return The parsed entity.
-     * @todo #51:30min Implement this method.
-     *  This method should parse the value and create an object.
      */
     private Entity createObject(final String value) {
         final Entity result;

--- a/src/main/java/org/objectionary/parsing/Entities.java
+++ b/src/main/java/org/objectionary/parsing/Entities.java
@@ -23,10 +23,13 @@
  */
 package org.objectionary.parsing;
 
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import org.objectionary.Tokenizer;
-import org.objectionary.entities.Entity;
+import org.objectionary.entities.*;
+import org.objectionary.tokens.StringToken;
+import org.objectionary.tokens.Token;
 
 /**
  * Entities reader.
@@ -56,7 +59,28 @@ public final class Entities {
      *  This method should read one entity recursively.
      */
     public Entity one() {
-        return null;
+        final Token token = tokenizer.getToken();
+        if (!(token instanceof StringToken)) {
+            throw new IllegalArgumentException("Expected string token");
+        }
+        final String value = ((StringToken) token).getValue();
+        final Entity result;
+        final TypeChecker type = new TypeChecker(value);
+        if (type.isEmpty()) {
+            result = new Empty();
+        } else if (type.isLocator()) {
+            result = new Locator(value);
+        } else if (type.isData()) {
+            result = new Data(Integer.parseInt(value.substring(2), 16));
+        } else if (type.isLambda()) {
+            result = new Lambda(value);
+        } else if (type.isObject()) {
+            result = createObject(tokenizer, value);
+        } else {
+            System.out.println(value);
+            throw new IllegalArgumentException("Unknown token");
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/objectionary/parsing/Entities.java
+++ b/src/main/java/org/objectionary/parsing/Entities.java
@@ -23,11 +23,16 @@
  */
 package org.objectionary.parsing;
 
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import org.objectionary.Tokenizer;
-import org.objectionary.entities.*;
+import org.objectionary.entities.Data;
+import org.objectionary.entities.Empty;
+import org.objectionary.entities.Entity;
+import org.objectionary.entities.FlatObject;
+import org.objectionary.entities.Lambda;
+import org.objectionary.entities.Locator;
+import org.objectionary.entities.NestedObject;
 import org.objectionary.tokens.StringToken;
 import org.objectionary.tokens.Token;
 
@@ -57,7 +62,7 @@ public final class Entities {
      * @return The parsed entity.
      */
     public Entity one() {
-        final Token token = tokenizer.getToken();
+        final Token token = this.tokenizer.getToken();
         if (!(token instanceof StringToken)) {
             throw new IllegalArgumentException("Expected string token");
         }
@@ -73,9 +78,8 @@ public final class Entities {
         } else if (type.isLambda()) {
             result = new Lambda(value);
         } else if (type.isObject()) {
-            result = createObject(value);
+            result = this.createObject(value);
         } else {
-            System.out.println(value);
             throw new IllegalArgumentException("Unknown token");
         }
         return result;
@@ -104,8 +108,8 @@ public final class Entities {
                 value.substring(value.indexOf('(') + 1, value.indexOf(')'))
             );
         } else if (value.contains("(")) {
-            tokenizer.next();
-            final Map<String, Entity> application = nested();
+            this.tokenizer.next();
+            final Map<String, Entity> application = this.nested();
             result = new NestedObject(
                 value.substring(0, value.indexOf('(')), application
             );

--- a/src/test/java/org/objectionary/EntitiesTest.java
+++ b/src/test/java/org/objectionary/EntitiesTest.java
@@ -44,7 +44,6 @@ import org.objectionary.parsing.Entities;
  */
 final class EntitiesTest {
 
-    @Disabled
     @Test
     void readOneEmptyTest() {
         final String input = "ø";
@@ -55,7 +54,6 @@ final class EntitiesTest {
         );
     }
 
-    @Disabled
     @Test
     void readOneLocatorTest() {
         final String input = "𝜋.𝜋.𝜋.x";
@@ -66,7 +64,6 @@ final class EntitiesTest {
         );
     }
 
-    @Disabled
     @Test
     void readOneLambdaTest() {
         final String input = "int-times";
@@ -77,7 +74,6 @@ final class EntitiesTest {
         );
     }
 
-    @Disabled
     @Test
     void readOneDataTest() {
         final String input = "0x0042";
@@ -88,7 +84,6 @@ final class EntitiesTest {
         );
     }
 
-    @Disabled
     @Test
     void readOneObjectTest() {
         final String input = "ν(𝜋)";


### PR DESCRIPTION
Closes: #51

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds public access modifiers to `hasNext()`, `getToken()` and `next()` methods in `Tokenizer.java`, and implements `Entities.one()` and `Entities.createObject()` methods in `Entities.java`.

### Detailed summary
- Changes access modifiers of `hasNext()`, `getToken()` and `next()` methods to `public` in `Tokenizer.java`.
- Implements `Entities.one()` and `Entities.createObject()` methods in `Entities.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->