### PR TITLE
Readme implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,57 @@
 # Flatty
 
-This project describes an optimization method for removing nesting from programs written in EO programming language. The nested structures in the language are composed of objects that form hierarchical structures, which can make it difficult to perform static analysis of such structures. The proposed method reframes expressions in such a way that they no longer contain nested objects, making it easier to perform static analysis. The project provides a formal proof of the correctness of the optimization method.
-### Run tests
+This project describes an optimization method for removing nesting from programs written in phi-calculus. The nested structures in the language are composed of objects that form hierarchical structures, which can make it difficult to perform static analysis of such structures. The proposed method reframes expressions in such a way that they no longer contain nested objects, making it easier to perform static analysis.
+
+### Quick start
+
+```
+import org.objectionary.Flatter;
+import org.objectionary.Parser;
+
+String[] lines = {
+    "ν1(𝜋) ↦ ⟦ x ↦ ν3, 𝜑 ↦ ν2( a ↦ ξ.x, b ↦ ξ.x ) ⟧",
+    "ν2(𝜋) ↦ ⟦ λ ↦ int-times, a ↦ ø, b ↦ ø ⟧",
+    "ν3(𝜋) ↦ ⟦ Δ ↦ 0x0007 ⟧",
+};
+Parser parser = new Parser(String.join("\n", lines));
+Flatter flatter = new Flatter(parser.parse());
+String result = flatter.flat().toString();
+```
+
+### Installation
+To use Flatty in your project, you can follow the steps below:
+
+1. Download the Flatty repository.
+
+2. Add the Flatty JAR file to your project's classpath.
+
+3. Import the necessary classes in your Java code:
+```
+import flatty.Parser;
+import flatty.Flatter;
+```
+
+### Usage
+
+The basic usage of Flatty involves the following steps:
+
+1. Use the Parser class to parse the input program written in EO.
+
+2. Create a Flatter object by passing the parsed program to it.
+
+3. Execute the flat method to optimize the program.
+
+Retrieve the optimized code as a string.
+
+### Examples
+
+You can find examples of some nested objects in the `src/test/java/org/objectionary/integration/resourses` directory.
+
+### Run unit-tests
 
     $  mvn clean install -Pqulice
+
+### Run integration tests
+
+    $  git clone https://github.com/objectionary/phie
+    $  python3 src/test/java/org/objectionary/integration/tester.py <path_to_phie_dir>


### PR DESCRIPTION
Closes: #57 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds usage instructions, installation steps, and examples to the README file of the Flatty repository. Additionally, it replaces mentions of the EO programming language with the phi-calculus language and removes a section on running tests.

### Detailed summary
- Adds a Quick Start section with usage instructions and code examples.
- Adds an Installation section with three steps to follow.
- Adds a Usage section with three steps to follow.
- Removes the Run Tests section.
- Adds an Examples section with a directory location to find nested objects.
- Updates the project description to refer to the phi-calculus language instead of the EO programming language.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->