### PR TITLE
implemented nested reading of entities

### DIFF
--- a/src/main/java/org/objectionary/parsing/Entities.java
+++ b/src/main/java/org/objectionary/parsing/Entities.java
@@ -33,6 +33,7 @@ import org.objectionary.entities.FlatObject;
 import org.objectionary.entities.Lambda;
 import org.objectionary.entities.Locator;
 import org.objectionary.entities.NestedObject;
+import org.objectionary.tokens.BracketToken;
 import org.objectionary.tokens.StringToken;
 import org.objectionary.tokens.Token;
 
@@ -88,11 +89,25 @@ public final class Entities {
     /**
      * Reads nested entity.
      * @return The parsed nested entity.
-     * @todo #49:30min Implement this method.
-     *  This method should read nested entity recursively.
      */
     public Map<String, Entity> nested() {
-        return new HashMap<>();
+        final Map<String, Entity> result = new HashMap<>();
+        while (true) {
+            final Token token = this.tokenizer.getToken();
+            if (token instanceof BracketToken) {
+                final BracketToken bracket = (BracketToken) token;
+                if (bracket.getState() == BracketToken.BracketType.CLOSE) {
+                    break;
+                }
+            }
+            final String name = ((StringToken) token).getValue();
+            this.tokenizer.next();
+            this.tokenizer.next();
+            final Entity entity = this.one();
+            result.put(name, entity);
+            this.tokenizer.next();
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/org/objectionary/EntitiesTest.java
+++ b/src/test/java/org/objectionary/EntitiesTest.java
@@ -25,6 +25,7 @@ package org.objectionary;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectionary.entities.Data;
@@ -32,6 +33,7 @@ import org.objectionary.entities.Empty;
 import org.objectionary.entities.FlatObject;
 import org.objectionary.entities.Lambda;
 import org.objectionary.entities.Locator;
+import org.objectionary.entities.NestedObject;
 import org.objectionary.parsing.Entities;
 
 /**
@@ -102,6 +104,36 @@ final class EntitiesTest {
         MatcherAssert.assertThat(
             reader.one(),
             Matchers.instanceOf(IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    void readOneNestedObject() {
+        final String input = "ν1( ρ ↦ ξ.ρ )";
+        final Entities reader = new Entities(new Tokenizer(input));
+        MatcherAssert.assertThat(
+            reader.one(),
+            Matchers.instanceOf(NestedObject.class)
+        );
+    }
+
+    @Test
+    void readOneDoubledNestedObject() {
+        final String input = "ν2( ν3 ↦ ν4( ρ ↦ ξ.ρ ) )";
+        final Entities reader = new Entities(new Tokenizer(input));
+        MatcherAssert.assertThat(
+            reader.one(),
+            Matchers.instanceOf(NestedObject.class)
+        );
+    }
+
+    @Test
+    void failedToReadOneNestedObject() {
+        final String input = "⟦ ν3 ↦ ν4( ρ ↦ ξ.ρ ) ⟧";
+        final Entities reader = new Entities(new Tokenizer(input));
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> reader.one()
         );
     }
 }


### PR DESCRIPTION
Closes: #52

This pull request just a duplicate of #59 and additional tests
<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing the `nested()` method in the `Entities` class. 

### Detailed summary
- Added import statement for `NestedObject`
- Implemented the `nested()` method to read nested entities recursively
- Added test cases for reading nested objects

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->